### PR TITLE
Address the 0.511 review (#4): housekeeping + global-state fix

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,12 +1,11 @@
 requires "DateTime::Format::ISO8601";
 requires "HTML::Entities";
 requires "HTML::TreeBuilder::XPath";
-requires "JSON";
+requires "JSON::MaybeXS";
 requires "List::Util";
 requires "URI";
 requires "Moo";
 requires "MooX::HandlesVia";
-requires "Readonly";
 requires "Scalar::Util";
 requires "Type::Tiny";
 

--- a/lib/Web/Microformats2/Document.pm
+++ b/lib/Web/Microformats2/Document.pm
@@ -2,7 +2,7 @@ package Web::Microformats2::Document;
 use Moo;
 use MooX::HandlesVia;
 use Encode qw(encode_utf8);
-use JSON qw(decode_json);
+use JSON::MaybeXS qw(decode_json);
 use List::Util qw(any);
 use Types::Standard qw(HashRef ArrayRef InstanceOf);
 
@@ -55,7 +55,8 @@ sub as_json {
         items => $self->top_level_items,
     };
 
-    return JSON->new->convert_blessed->utf8->encode( $data_for_json );
+    return JSON::MaybeXS->new( convert_blessed => 1, utf8 => 1 )
+        ->encode( $data_for_json );
 }
 
 sub as_raw_data {

--- a/lib/Web/Microformats2/Item.pm
+++ b/lib/Web/Microformats2/Item.pm
@@ -4,60 +4,24 @@ use MooX::HandlesVia;
 use Types::Standard qw(HashRef ArrayRef Str Maybe InstanceOf);
 use Carp;
 
-has 'properties' => (
-    is => 'ro',
-    isa => HashRef,
-    handles_via => 'Hash',
-    default => sub { {} },
-    handles => {
-        has_properties => 'count',
-        has_property   => 'get',
-    },
-);
-
-has 'p_properties' => (
-    is => 'ro',
-    isa => HashRef,
-    handles_via => 'Hash',
-    default => sub { {} },
-    handles => {
-        has_p_properties => 'count',
-        has_p_property   => 'get',
-    },
-);
-
-has 'u_properties' => (
-    is => 'ro',
-    isa => HashRef,
-    handles_via => 'Hash',
-    default => sub { {} },
-    handles => {
-        has_u_properties => 'count',
-        has_u_property   => 'get',
-    },
-);
-
-has 'e_properties' => (
-    is => 'ro',
-    isa => HashRef,
-    handles_via => 'Hash',
-    default => sub { {} },
-    handles => {
-        has_e_properties => 'count',
-        has_e_property   => 'get',
-    },
-);
-
-has 'dt_properties' => (
-    is => 'ro',
-    isa => HashRef,
-    handles_via => 'Hash',
-    default => sub { {} },
-    handles => {
-        has_dt_properties => 'count',
-        has_dt_property   => 'get',
-    },
-);
+# The MF2 property stores: one catch-all ('properties') plus one per typed
+# prefix (p-, u-, e-, dt-). They are identical in shape, so declare them in a
+# loop. Each gets has_<name>_properties (count) and has_<name>_property (get)
+# accessors; the catch-all uses the bare has_properties / has_property names.
+for my $prefix ( '', qw( p u e dt ) ) {
+    my $attr = $prefix ? "${prefix}_properties" : 'properties';
+    my $stem = $prefix ? "${prefix}_propert"    : 'propert';
+    has $attr => (
+        is => 'ro',
+        isa => HashRef,
+        handles_via => 'Hash',
+        default => sub { {} },
+        handles => {
+            "has_${stem}ies" => 'count',
+            "has_${stem}y"   => 'get',
+        },
+    );
+}
 has 'parent' => (
     is => 'ro',
     isa => Maybe[InstanceOf['Web::Microformats2::Item']],
@@ -173,6 +137,11 @@ sub all_types {
     return @types;
 }
 
+# TO_JSON: This is the hook the JSON encoder calls on each item while
+# serializing (under convert_blessed), returning an unblessed structure -- it
+# is not meant to be called directly. The public, document-level entry point
+# for getting a JSON string is Web::Microformats2::Document::as_json, which
+# drives that encoder over the whole item tree.
 sub TO_JSON {
     my $self = shift;
 

--- a/lib/Web/Microformats2/Parser.pm
+++ b/lib/Web/Microformats2/Parser.pm
@@ -6,15 +6,12 @@ use HTML::TreeBuilder::XPath;
 use HTML::Entities;
 use v5.10;
 use Scalar::Util qw(blessed);
-use JSON;
 use DateTime::Format::ISO8601;
 use URI;
 use Carp;
 
 use Web::Microformats2::Item;
 use Web::Microformats2::Document;
-
-use Readonly;
 
 has 'url_context' => (
     is => 'rw',
@@ -40,10 +37,17 @@ sub parse {
     $tree->ignore_ignorable_whitespace( 0 );
     $tree->no_expand_entities( 1 );
 
-    # Adding HTML5 elements because it's 2018.
-    foreach (qw(article aside details figcaption figure footer header main mark nav section summary time)) {
-        $HTML::TreeBuilder::isBodyElement{$_}=1;
-    }
+    # Teach HTML::TreeBuilder about HTML5 elements so it treats them as body
+    # content. Scope this with `local` so the parse doesn't permanently mutate
+    # the package global for everyone else using HTML::TreeBuilder in this
+    # process; the override stays in effect for the dynamic extent of parse().
+    local %HTML::TreeBuilder::isBodyElement = (
+        %HTML::TreeBuilder::isBodyElement,
+        map { $_ => 1 } qw(
+            article aside details figcaption figure footer header main
+            mark nav section summary time
+        ),
+    );
 
     $tree->parse( $html );
 

--- a/t/global-state.t
+++ b/t/global-state.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+use Test::More;
+
+use HTML::TreeBuilder;
+use Web::Microformats2::Parser;
+
+# The parser teaches HTML::TreeBuilder about HTML5 elements so it can find
+# microformats nested inside them. That teaching must be scoped to the parse
+# call: it must not permanently mutate the %HTML::TreeBuilder::isBodyElement
+# package global and leak into everyone else using HTML::TreeBuilder in the
+# same process. (See issue #11.)
+
+my @html5_elements = qw(
+    article aside details figcaption figure footer header main
+    mark nav section summary time
+);
+
+# Snapshot which of these the global already treats as body elements, before
+# we run any parse, so the assertion is robust to HTML::TreeBuilder versions
+# that already know some HTML5 tags.
+my %known_before =
+    map  { $_ => 1 }
+    grep { $HTML::TreeBuilder::isBodyElement{ $_ } }
+    @html5_elements;
+
+my $parser = Web::Microformats2::Parser->new;
+$parser->parse(
+    '<article><div class="h-card"><span class="p-name">Alice</span></div></article>'
+);
+
+my @leaked =
+    grep { $HTML::TreeBuilder::isBodyElement{ $_ } && !$known_before{ $_ } }
+    @html5_elements;
+
+is_deeply( \@leaked, [],
+    'parse() does not permanently pollute %HTML::TreeBuilder::isBodyElement' )
+    or diag( "Leaked global isBodyElement keys: @leaked" );
+
+done_testing;

--- a/t/item-accessors.t
+++ b/t/item-accessors.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Web::Microformats2::Item;
+
+# The five prefix-keyed property attributes (plain, p-, u-, e-, dt-) are
+# identical in shape and a candidate for being generated in a loop (issue #12).
+# Whatever the implementation, every prefix must still expose its has_*
+# accessors and behave as a per-prefix property store. This guards the refactor.
+
+my %accessors = (
+    ''   => [ qw( has_properties    has_property    ) ],
+    'p-' => [ qw( has_p_properties  has_p_property  ) ],
+    'u-' => [ qw( has_u_properties  has_u_property  ) ],
+    'e-' => [ qw( has_e_properties  has_e_property  ) ],
+    'dt-'=> [ qw( has_dt_properties has_dt_property ) ],
+);
+
+my $item = Web::Microformats2::Item->new( types => [ 'entry' ] );
+
+for my $prefix ( sort keys %accessors ) {
+    can_ok( $item, $_ ) for @{ $accessors{ $prefix } };
+}
+
+# Each prefix store should be independently addressable: adding a property
+# under one prefix lands in that prefix's store and nowhere else.
+$item->add_property( 'p-name', 'Alice' );
+$item->add_property( 'u-url',  'http://example.com/' );
+
+is_deeply( $item->get_properties( 'name' ), [ 'Alice' ],
+    'p- property is retrievable' );
+is_deeply( $item->get_properties( 'url' ), [ 'http://example.com/' ],
+    'u- property is retrievable' );
+
+ok( $item->has_p_property( 'name' ), 'name is stored in the p- prefix store' );
+ok( $item->has_u_property( 'url' ),  'url is stored in the u- prefix store' );
+ok( !$item->has_u_property( 'name' ),
+    'name did not leak into the u- prefix store' );
+
+done_testing;

--- a/t/parse.t
+++ b/t/parse.t
@@ -4,7 +4,7 @@ use Test::Deep;
 use List::Util qw(first);
 use Path::Class::Dir;
 use FindBin;
-use JSON;
+use JSON::MaybeXS;
 
 use_ok ("Web::Microformats2");
 


### PR DESCRIPTION
Works through the actionable items from @shadowcat-mst's six-year-old "fat issue" #4, broken out into sub-issues #9–#13.

## What's here

- **#9** — `use JSON` → `use JSON::MaybeXS` (picks the best available backend). Also dropped the import from `Parser.pm`, where it was unused.
- **#10** — Removed the `Readonly` import. The review suggested swapping it for `Const::Fast`, but it was imported and never used, so the honest fix is deletion.
- **#11** — `local`-scoped the HTML5 `isBodyElement` override. `parse()` was permanently mutating `%HTML::TreeBuilder::isBodyElement`, leaking into anyone else using HTML::TreeBuilder in the same process. The override now lasts only for the dynamic extent of `parse()`. **This is the one real behavioral fix.**
- **#12** — Collapsed the five identical prefix property attributes in `Item.pm` into a loop.
- **#13** — Added a comment clarifying `TO_JSON` (the encoder hook) vs `as_json` (the public stringifier).

## Tests (TDD)

- `t/global-state.t` — written **failing-first** against the old code (it leaked all 13 HTML5 tags into the global); now green with the `local` fix.
- `t/item-accessors.t` — guards the #12 refactor: asserts all five prefix stores keep their `has_*` accessors and stay independently addressable.
- The official MF2 baseline suite (`t/parse.t`, `t/document.t`) stays green, which is the proof that #9/#10/#12 are behavior-preserving refactors.

Deliberately **not** included: the Mojo::DOM58 migration and the `analyze_element` restructuring from #4 — both are large rewrites that trade test-backed code for elegance, better left as their own deliberate efforts.

Closes #9, closes #10, closes #11, closes #12, closes #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)